### PR TITLE
Fix type for coord to geopoint

### DIFF
--- a/field_definitions.tsv
+++ b/field_definitions.tsv
@@ -52,7 +52,7 @@ region	string	default	Park, county, district, lake or river.
 sector	string	default	Sector of park or county/city.
 site	string	default	The name of the sampling location.
 site_code	string	default	A short string representing the sampling location.
-coord	string	default	Latitude & Longitude in decimal degrees (DD) format (e.g. 45.837).
+coord	geopoint	array	Latitude & Longitude in decimal degrees (DD) format (e.g. 45.837).
 coord_accuracy	float	default	Accuracy of coordinate in decimal degrees (DD).
 coord_source	string	default	The source of the coordinates.
 elev	float	default	Elevation of sampling site. Measured in meters relative to sea level. Negative values indicate a position below sea level.

--- a/mapping_BCDM_to_DWC.tsv
+++ b/mapping_BCDM_to_DWC.tsv
@@ -51,7 +51,7 @@ region	county	string	default	default	string
 sector	municipality	string	default	default	string
 site	verbatimLocality	string	default	default	string
 site_code	parentEventID	string	default	default	string
-coord	decimalLatitude & decimalLongitude	string	default	default	array
+coord	decimalLatitude & decimalLongitude	geopoint	array	default	array
 coord_accuracy	coordinatePrecision	float	default	default	float
 coord_source	georeferenceSources	string	default	default	string
 elev	verbatimElevation	float	default	default	float


### PR DESCRIPTION
Corrects the type for `coord` in both `field_defintions.tsv` and the conversion file for DWC.