### PR TITLE
corrected tab field separator on line 76

### DIFF
--- a/field_definitions.tsv
+++ b/field_definitions.tsv
@@ -73,6 +73,6 @@ sequence_upload_date	string:date	%Y-%m-%d	Date the sequence was uploaded.
 bold_recordset_code_arr	array	default	A comma separated list of Projects and Datasets on BOLD that this record is associated with.
 ecoregion	string	default	Inferred RESOLVE defined ecoregion based on the collection coordinates.
 biome	string	default	Inferred RESOLVE defined biome based on the collection coordinates.
-realm  string  default  Inferred RESOLVE defined realm based on collection coordinates.
+realm	string	default	Inferred RESOLVE defined realm based on collection coordinates.
 sovereign_inst	string	default	Institution with sovereignty over the physical specimen.
 


### PR DESCRIPTION
The description of `realm` was malformatted, with fields being separated by spaces rather than tabs. This broke tabular rendering on github and would similarly break any TSV parsing downstream. Corrected in this patch.